### PR TITLE
AL - Fix Storybook Deployment Scripts

### DIFF
--- a/.github/workflows/publish-docs-to-github-pages-qa.yml
+++ b/.github/workflows/publish-docs-to-github-pages-qa.yml
@@ -13,10 +13,10 @@ jobs:
         with:
           persist-credentials: false
       - name: Install and Build 🔧
-        working-directory: ./frontend
+        working-directory: ./javascript
         run: | # Install npm packages and build the Storybook files
           npm install
-          mkdir -p storybook-static
+          mkdir -p docs-build
           npm run build-storybook
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@4.1.0
@@ -24,6 +24,6 @@ jobs:
           repository-name: ${{ github.repository }}-docs-qa
           token: ${{ secrets.TOKEN }}
           branch: main # The branch the action should deploy to.
-          folder: javascript/storybook-static # The folder that the build-storybook script generates files.
+          folder: javascript/docs-build # The folder that the build-storybook script generates files.
           clean: true # Automatically remove deleted files from the deploy branch
           target-folder: docs/storybook # The folder that we serve our Storybook files from 

--- a/.github/workflows/publish-docs-to-github-pages.yml
+++ b/.github/workflows/publish-docs-to-github-pages.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Install and Build 🔧
-        working-directory: ./frontend
+        working-directory: ./javascript
         run: | # Install npm packages and build the Storybook files
           npm install
           mkdir -p docs-build
@@ -24,6 +24,6 @@ jobs:
           repository-name: ${{ github.repository }}-docs
           token: ${{ secrets.TOKEN }}
           branch: main # The branch the action should deploy to.
-          folder: javascript/storybook-static # The folder that the build-storybook script generates files.
+          folder: javascript/docs-build # The folder that the build-storybook script generates files.
           clean: true # Automatically remove deleted files from the deploy branch
           target-folder: docs/storybook # The folder that we serve our Storybook files from 


### PR DESCRIPTION
This PR fixes the storybook deployment scripts to enter the correct working directory (`javascript` instead of `frontend`) and to deploy from the correct build directory (`docs-build` instead of `storybook-static`). 

Tested with [STARTER-team02-docs](https://ucsb-cs156-s21.github.io/STARTER-team02-docs/storybook/) and [STARTER-team02-docs-qa](https://ucsb-cs156-s21.github.io/STARTER-team02-docs-qa/storybook/)